### PR TITLE
Support for ARM/Raspberry pi

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,9 +71,9 @@ var serialNumber = function (cb, cmdPrefix) {
 		cmd = 'system_profiler SPHardwareDataType | grep ';
 		break;
 
-	case 'freebsd':
 	case 'linux':
 		if (process.arch === 'arm') {
+			vals[1] = 'Serial';
 			cmd = 'cat /proc/cpuinfo | grep ';
 			
 		} else {
@@ -81,6 +81,9 @@ var serialNumber = function (cb, cmdPrefix) {
 		}
 		break;
 	}
+	
+	case 'freebsd':
+		cmd = 'dmidecode -t system | grep ';
 
 	if (!cmd) return cb(new Error('Cannot provide serial number for ' + process.platform));
 

--- a/index.js
+++ b/index.js
@@ -71,9 +71,14 @@ var serialNumber = function (cb, cmdPrefix) {
 		cmd = 'system_profiler SPHardwareDataType | grep ';
 		break;
 
-	case 'linux':
 	case 'freebsd':
-		cmd = 'dmidecode -t system | grep ';
+	case 'linux':
+		if (process.arch === 'arm') {
+			cmd = 'cat /proc/cpuinfo | grep ';
+			
+		} else {
+			cmd = 'dmidecode -t system | grep ';	
+		}
 		break;
 	}
 


### PR DESCRIPTION
Arm architectures do not have the dmidecode command.  On the Raspberry pi the serial can be obtained with `cat /proc/cpuinfo | grep Serial`
